### PR TITLE
add: Virtualization for library entries list

### DIFF
--- a/src/app/renderer/src/app/app/library/page.tsx
+++ b/src/app/renderer/src/app/app/library/page.tsx
@@ -30,6 +30,7 @@ import { getMedia } from "@/lib/db/utils";
 import { getMediaTitle } from "@/lib/settings";
 import { Messages } from "@/lib/messages/translations";
 import { useMessages } from "@/lib/messages";
+import VirtualList from "@/components/VirtualList";
 
 interface LibraryEntryWithMedia extends LibraryEntry {
     media?: Media;
@@ -43,6 +44,10 @@ const statusColors: { [key in LibraryStatus]: { [key: string]: string } } = {
     dropped: colors.red,
     completed: colors.green,
 };
+
+function remToPx(rem: number) {
+    return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
+}
 
 export default function Library() {
     const [mediaTypeFilters, setMediaTypeFilters] = React.useState<
@@ -269,17 +274,26 @@ export default function Library() {
                 <div className="flex-1 flex flex-col overflow-y-auto relative">
                     {libraryEntries ? (
                         libraryEntries.length > 0 ? (
-                            <div className="p-4 flex flex-col gap-4">
-                                {libraryEntries.map((entry) => (
-                                    <LibraryEntryRow
-                                        key={entry.mapping}
-                                        entry={entry}
-                                        openModal={() =>
-                                            setOpenModalMapping(entry.mapping)
-                                        }
-                                    />
-                                ))}
-                            </div>
+                            <VirtualList
+                                className="flex flex-col flex-1"
+                                style={{
+                                    padding: "0.5rem",
+                                }}
+                                items={libraryEntries}
+                                component={({ item, index }: { item: LibraryEntryWithMedia; index: number }) => {
+                                    return (
+                                        <LibraryEntryRow
+                                            key={item.mapping}
+                                            entry={item}
+                                            openModal={() => {
+                                                setOpenModalMapping(item.mapping);
+                                            }}
+                                        />
+                                    );
+                                }}
+                                componentSize={remToPx(3.5)}
+                                overscan={5}
+                            />
                         ) : (
                             <div className="flex-1 flex flex-col justify-center items-center text-zinc-300">
                                 <div className="mb-2">(╥﹏╥)</div>
@@ -350,7 +364,7 @@ function LibraryEntryRow({
 
     return (
         <div
-            className="flex flex-row items-strtetch gap-4 p-2 -m-2 relative hover:bg-zinc-800 rounded transition cursor-pointer group"
+            className="flex flex-row items-strtetch gap-4 p-2 relative hover:bg-zinc-800 rounded transition cursor-pointer group"
             onClick={() => openModal()}
         >
             <div

--- a/src/app/renderer/src/components/VirtualList/index.tsx
+++ b/src/app/renderer/src/components/VirtualList/index.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+export default function VirtualList({
+    items,
+    component,
+    componentSize,
+    overscan = 1,
+    ...props
+}: {
+    items: any[];
+    component: (options: { item: any; index: number }) => React.JSX.Element;
+    componentSize: number;
+    overscan?: number;
+    [key: string]: any;
+}) {
+    const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+    const style = { ...(props.style ?? {}), overflow: "auto" };
+    delete props.style;
+
+    const [renderFrom, setRenderFrom] = React.useState(
+        0
+    );
+    const [renderTo, setRenderTo] = React.useState(
+        containerRef.current?.offsetHeight! / componentSize
+    );
+
+    React.useEffect(() => {
+        function handleScroll(e: any) {
+            const rf = Math.floor(e.target.scrollTop / componentSize);
+            const rt = rf + Math.ceil(e.target.offsetHeight / componentSize);
+
+            const rfState = Math.max(rf - overscan, 0);
+            const rtState = Math.min(rt + overscan, items.length);
+
+            if (renderFrom != rfState) {
+                setRenderFrom(rfState);
+            }
+
+            if (renderTo != rtState) {
+                setRenderTo(rtState);
+            }
+        }
+
+        if (containerRef.current) {
+            containerRef.current.addEventListener("scroll", handleScroll);
+
+            handleScroll({ target: containerRef.current });
+        }
+
+        return () => {
+            containerRef.current?.removeEventListener("scroll", handleScroll);
+        };
+    }, [renderFrom, renderTo]);
+
+    return (
+        <div ref={containerRef} style={style} {...props}>
+            <div>
+                <div
+                    style={{
+                        height: `${renderFrom * componentSize}px`,
+                    }}
+                ></div>
+            </div>
+            {items
+                .slice(renderFrom, renderTo)
+                .map((item, index) => component({ item, index }))}
+            <div>
+                <div
+                    style={{
+                        height: `${
+                            (items.length - renderTo) * componentSize
+                        }px`,
+                    }}
+                ></div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/renderer/src/components/VirtualList/index.tsx
+++ b/src/app/renderer/src/components/VirtualList/index.tsx
@@ -51,7 +51,7 @@ export default function VirtualList({
         return () => {
             containerRef.current?.removeEventListener("scroll", handleScroll);
         };
-    }, [renderFrom, renderTo]);
+    }, [renderFrom, renderTo, items]);
 
     return (
         <div ref={containerRef} style={style} {...props}>


### PR DESCRIPTION
Now the app only renders those items that are visible, together with some extra ones above and below to smoothen the scrolling. This will considerably reduce lag in the library page.